### PR TITLE
allow use of -race when building/testing gls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
-/coverage.txt
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Editors, etc.
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/modern-go/gls
+
+go 1.19
+
+require github.com/modern-go/reflect2 v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=

--- a/goid.go
+++ b/goid.go
@@ -1,8 +1,9 @@
 package gls
 
 import (
-	"github.com/modern-go/reflect2"
 	"unsafe"
+
+	"github.com/modern-go/reflect2"
 )
 
 // offset for go1.4
@@ -18,6 +19,9 @@ func init() {
 }
 
 // GoID returns the goroutine id of current goroutine
+//
+//go:nosplit
+//go:norace
 func GoID() int64 {
 	g := getg()
 	p_goid := (*int64)(unsafe.Pointer(g + goidOffset))


### PR DESCRIPTION
Allow build with `-race` (see `GoID`) via build annotations

* also: add go.mod